### PR TITLE
Fixed out of bounds bug on resize when rows and cols are increased.

### DIFF
--- a/TermEmulator/TermEmulator.py
+++ b/TermEmulator/TermEmulator.py
@@ -260,7 +260,9 @@ class V102Terminal:
                 self.screen.append(line)
                 self.scrRendition.append(rendition)
                 self.isLineDirty.append(False)
-                
+
+        self.rows = rows
+
         if cols < self.cols:
             # remove cols at right
             for i in range(self.rows):
@@ -274,7 +276,6 @@ class V102Terminal:
                     self.screen[i].append(u' ')
                     self.scrRendition[i].append(0)
         
-        self.rows = rows
         self.cols = cols
         
     def GetCursorPos(self):


### PR DESCRIPTION
If the terminal is resized and rows and cols are increased at the same time, TermEmulator can crash with an out of bounds error. The fix is to set self.rows to the new, increased row count, before the new columns are handled. This ensures the correct number of new columns are added not just to the original rows, but also to the newly added rows.